### PR TITLE
remove dependency to js-base64

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,16 +35,15 @@
     "@types/express": "*",
     "express": "^4.17.3",
     "express-promise-router": "^4.1.0",
-    "winston": "^3.2.1",
     "node-fetch": "^2.6.7",
-    "yn": "^4.0.0",
-    "js-base64": "^3.7.3"
+    "winston": "^3.2.1",
+    "yn": "^4.0.0"
   },
   "devDependencies": {
     "@backstage/cli": "^0.22.11",
     "@types/supertest": "^2.0.12",
-    "supertest": "^6.2.4",
-    "msw": "^0.49.0"
+    "msw": "^0.49.0",
+    "supertest": "^6.2.4"
   },
   "files": [
     "dist",

--- a/src/clients/KeycloakConnector.ts
+++ b/src/clients/KeycloakConnector.ts
@@ -14,11 +14,10 @@
  * limitations under the License.
  */
 
-import { Base64 } from 'js-base64'
 
 export function connectAndGetOAuthToken(tokenEndpoint: string, serviceAccount: string, serviceAccountCredentials: string): Promise<string> {
 
-  const credentials: string = Base64.encode(serviceAccount + ':' + serviceAccountCredentials);
+  const credentials: string = Buffer.from(serviceAccount + ':' + serviceAccountCredentials).toString('base64');
 
   return fetch(tokenEndpoint, {
     method: 'POST',

--- a/yarn.lock
+++ b/yarn.lock
@@ -9215,11 +9215,6 @@ joycon@^3.0.1:
   resolved "https://registry.npmjs.org/joycon/-/joycon-3.1.1.tgz"
   integrity sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==
 
-js-base64@^3.7.3:
-  version "3.7.3"
-  resolved "https://registry.npmjs.org/js-base64/-/js-base64-3.7.3.tgz"
-  integrity sha512-PAr6Xg2jvd7MCR6Ld9Jg3BmTcjYsHEBx1VlwEwULb/qowPf5VD9kEMagj23Gm7JRnSvE/Da/57nChZjnvL8v6A==
-
 js-levenshtein@^1.1.6:
   version "1.1.6"
   resolved "https://registry.npmjs.org/js-levenshtein/-/js-levenshtein-1.1.6.tgz"


### PR DESCRIPTION
### Description

Remove the dependency to `js-base64` using the platform-provided APIs to allow installation on Red Hat Developer Hub.

### Related issue(s)

fixes #12 