### PR TITLE
Hguerrer fix 14 owner system labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Microcks Backstage provider
 
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/microcks/microcks-backstage-provider/build-verify.yml?logo=github&style=for-the-badge)](https://github.com/microcks/microcks-backstage-provider/actions)
 [![Version](https://img.shields.io/npm/v/@microcks/microcks-backstage-provider?color=blue&style=for-the-badge)]((https://search.maven.org/artifact/io.github.microcks/microcks))
 [![License](https://img.shields.io/github/license/microcks/microcks?style=for-the-badge&logo=apache)](https://www.apache.org/licenses/LICENSE-2.0)
-[![Project Chat](https://img.shields.io/badge/chat-on_zulip-pink.svg?color=ff69b4&style=for-the-badge&logo=zulip)](https://microcksio.zulipchat.com/)
+[![Project Chat](https://img.shields.io/badge/discord-microcks-pink.svg?color=7289da&style=for-the-badge&logo=discord)](https://microcks.io/discord-invite/)
 
 This is a plugin for synchronizing Microcks content into [Backstage.io](https://backstage.io/) catalog.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@microcks/microcks-backstage-provider",
+  "name": "microcks-backstage-provider",
   "version": "0.0.4",
   "author": "Laurent Broudoux <laurent@microcks.io>",
   "repository": {

--- a/package.json
+++ b/package.json
@@ -20,17 +20,14 @@
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
-    "export-dynamic": "janus-cli package export-dynamic-plugin",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack",
-    "postversion": "yarn run export-dynamic"
+    "postpack": "backstage-cli package postpack"
   },
   "dependencies": {
     "@backstage/backend-common": "^0.19.3",
-    "@backstage/backend-plugin-manager": "npm:@janus-idp/backend-plugin-manager@0.0.2-janus.5",
     "@backstage/backend-tasks": "^0.5.6",
     "@backstage/catalog-model": "^1.4.1",
     "@backstage/config": "^1.0.8",
@@ -44,17 +41,13 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.22.11",
-    "@janus-idp/cli": "^1.5.0",
     "@types/supertest": "^2.0.12",
     "msw": "^0.49.0",
     "supertest": "^6.2.4"
   },
   "files": [
     "dist",
-    "config.d.ts",
-    "dist-dynamic/*.*",
-    "dist-dynamic/dist/**",
-    "dist-dynamic/alpha/*"
+    "config.d.ts"
   ],
   "configSchema": "config.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@microcks/microcks-backstage-provider",
+  "name": "microcks-backstage-provider",
   "version": "0.0.4",
   "author": "Laurent Broudoux <laurent@microcks.io>",
   "repository": {
@@ -20,14 +20,17 @@
   "scripts": {
     "start": "backstage-cli package start",
     "build": "backstage-cli package build",
+    "export-dynamic": "janus-cli package export-dynamic-plugin",
     "lint": "backstage-cli package lint",
     "test": "backstage-cli package test",
     "clean": "backstage-cli package clean",
     "prepack": "backstage-cli package prepack",
-    "postpack": "backstage-cli package postpack"
+    "postpack": "backstage-cli package postpack",
+    "postversion": "yarn run export-dynamic"
   },
   "dependencies": {
     "@backstage/backend-common": "^0.19.3",
+    "@backstage/backend-plugin-manager": "npm:@janus-idp/backend-plugin-manager@0.0.2-janus.5",
     "@backstage/backend-tasks": "^0.5.6",
     "@backstage/catalog-model": "^1.4.1",
     "@backstage/config": "^1.0.8",
@@ -41,13 +44,17 @@
   },
   "devDependencies": {
     "@backstage/cli": "^0.22.11",
+    "@janus-idp/cli": "^1.5.0",
     "@types/supertest": "^2.0.12",
     "msw": "^0.49.0",
     "supertest": "^6.2.4"
   },
   "files": [
     "dist",
-    "config.d.ts"
+    "config.d.ts",
+    "dist-dynamic/*.*",
+    "dist-dynamic/dist/**",
+    "dist-dynamic/alpha/*"
   ],
   "configSchema": "config.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "microcks-backstage-provider",
+  "name": "@microcks/microcks-backstage-provider",
   "version": "0.0.4",
   "author": "Laurent Broudoux <laurent@microcks.io>",
   "repository": {

--- a/src/providers/MicrocksApiEntityProvider.ts
+++ b/src/providers/MicrocksApiEntityProvider.ts
@@ -357,13 +357,13 @@ export class MicrocksApiEntityProvider implements EntityProvider {
     if (this.systemLabel && service.metadata.labels && service.metadata.labels[this.systemLabel]) {
       return service.metadata.labels[this.systemLabel];
     }
-    return '';
+    return 'microcks';
   }
 
   private getApiEntityOwner(service: Service): string {
     if (this.ownerLabel && service.metadata.labels && service.metadata.labels[this.ownerLabel]) {
       return service.metadata.labels[this.ownerLabel];
     }
-    return '';
+    return 'microcks';
   }
 }


### PR DESCRIPTION
### Description

This uses `microcks` as the default system and owner labels to be compliant.

### Related issue(s)

#14 